### PR TITLE
API 명세서 업데이트

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,13 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.springframework.restdocs</groupId>
+            <artifactId>spring-restdocs-mockmvc</artifactId>
+            <version>2.0.2.RELEASE</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -119,7 +126,7 @@
             <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
-                <version>1.5.3</version>
+                <version>1.5.8</version>
                 <executions>
                     <execution>
                         <id>generate-docs</id>

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -67,62 +67,252 @@ UAD2 스프링 API 서버
 | 요청한 리소스 존재하지 않음.
 |===
 
-[[API]]
-== API
+
+
+[[member-API]]
+== 회원 API
 
 [[getAllMembers]]
-=== 멤버 전체 조회
+=== 회원 전체 조회
 
 ==== Request HTTP
-include::{snippets}/sample/getAllMembers/http-request.adoc[]
+include::{snippets}/member/getAllMembers/http-request.adoc[]
 
 ==== Response
-include::{snippets}/sample/getAllMembers/response-fields.adoc[]
+include::{snippets}/member/getAllMembers/response-fields.adoc[]
 
 ==== Response paging link
-include::{snippets}/sample/getAllMembers/links.adoc[]
+include::{snippets}/member/getAllMembers/links.adoc[]
 
 [[getMemberById]]
-=== 멤버 개별 조회 by id
+=== 회원 개별 조회 by id
 
 ==== Request HTTP
-include::{snippets}/sample/getMemberById/http-request.adoc[]
+include::{snippets}/member/getMemberById/http-request.adoc[]
 
 ==== Request path parameters
-include::{snippets}/sample/getMemberById/path-parameters.adoc[]
+include::{snippets}/member/getMemberById/path-parameters.adoc[]
 
 ==== Response Body
-include::{snippets}/sample/getMemberById/response-body.adoc[]
+include::{snippets}/member/getMemberById/response-body.adoc[]
 
 ==== Response
-include::{snippets}/sample/getMemberById/response-fields.adoc[]
+include::{snippets}/member/getMemberById/response-fields.adoc[]
 
 
 [[getMemberById_badRequest_emptyParameter]]
 === 개별 회원 조회 에러(매개변수 미기입)
 
 ==== Request HTTP
-include::{snippets}/sample/getMemberById_badRequest_emptyParameter/http-request.adoc[]
+include::{snippets}/member/getMemberById_badRequest_emptyParameter/http-request.adoc[]
 
 ==== Request path parameters
-include::{snippets}/sample/getMemberById_badRequest_emptyParameter/path-parameters.adoc[]
+include::{snippets}/member/getMemberById_badRequest_emptyParameter/path-parameters.adoc[]
 
 ==== Response Body
-include::{snippets}/sample/getMemberById_badRequest_emptyParameter/response-body.adoc[]
+include::{snippets}/member/getMemberById_badRequest_emptyParameter/response-body.adoc[]
 
 
 [[createMember]]
-=== 멤버 생성
+=== 회원 생성
 
 ==== Request HTTP
-include::{snippets}/sample/createMember/http-request.adoc[]
+include::{snippets}/member/createMember/http-request.adoc[]
 
 ==== Request
-include::{snippets}/sample/createMember/request-fields.adoc[]
+include::{snippets}/member/createMember/request-fields.adoc[]
 
 ==== Response Body
-include::{snippets}/sample/createMember/response-body.adoc[]
+include::{snippets}/member/createMember/response-body.adoc[]
 
 ==== Response
-include::{snippets}/sample/createMember/response-fields.adoc[]
+include::{snippets}/member/createMember/response-fields.adoc[]
 
+
+[[checkPwd]]
+=== 비밀번호 체크
+프로필 수정을 위한 비밀번호 검증 API
+
+==== Request HTTP
+include::{snippets}/member/checkPwd/http-request.adoc[]
+
+==== Request
+include::{snippets}/member/checkPwd/request-fields.adoc[]
+
+==== Response Body
+include::{snippets}/member/checkPwd/response-body.adoc[]
+
+==== Response
+include::{snippets}/member/checkPwd/response-fields.adoc[]
+
+
+
+[[attendance-API]]
+== 참가 API
+
+
+[[getAllAttendances]]
+=== 특정일 참가 내역 조회
+특정일에 참가 신청한 내역 조회 API
+
+==== Request path parameters
+include::{snippets}/attendance/getAllAttendances/path-parameters.adoc[]
+
+==== Response Body
+include::{snippets}/attendance/getAllAttendances/response-body.adoc[]
+
+==== Response
+include::{snippets}/attendance/getAllAttendances/response-fields.adoc[]
+
+==== Response paging link
+include::{snippets}/attendance/getAllAttendances/links.adoc[]
+
+
+[[createAttendance_updateMatching]]
+=== 참가 데이터 생성
+
+==== Request HTTP
+include::{snippets}/attendance/createAttendance_updateMatching/http-request.adoc[]
+
+==== Request
+include::{snippets}/attendance/createAttendance_updateMatching/request-fields.adoc[]
+
+==== Response Body
+include::{snippets}/attendance/createAttendance_updateMatching/response-body.adoc[]
+
+==== Response
+include::{snippets}/attendance/createAttendance_updateMatching/response-fields.adoc[]
+
+==== Response paging link
+include::{snippets}/attendance/createAttendance_updateMatching/links.adoc[]
+
+
+[[updateAttendance]]
+=== 참가 데이터 수정
+
+==== Request HTTP
+include::{snippets}/attendance/updateAttendance/http-request.adoc[]
+
+==== Request
+include::{snippets}/attendance/updateAttendance/request-fields.adoc[]
+
+==== Response Body
+include::{snippets}/attendance/updateAttendance/response-body.adoc[]
+
+==== Response
+include::{snippets}/attendance/updateAttendance/response-fields.adoc[]
+
+==== Response paging link
+include::{snippets}/attendance/updateAttendance/links.adoc[]
+
+
+[[deleteAttendance]]
+=== 참가 데이터 삭제
+
+==== Request HTTP
+include::{snippets}/attendance/deleteAttendance/http-request.adoc[]
+
+==== Request
+include::{snippets}/attendance/deleteAttendance/request-fields.adoc[]
+
+==== Response
+include::{snippets}/attendance/deleteAttendance/http-response.adoc[]
+
+
+[[getAttendance_byMemberSeqAndDate]]
+=== 특정 회원의 참가 데이터 조회 by memberSeq & date
+
+==== Request HTTP
+include::{snippets}/attendance/getAttendance_byMemberSeqAndDate/http-request.adoc[]
+
+==== Request path parameters
+include::{snippets}/attendance/getAttendance_byMemberSeqAndDate/path-parameters.adoc[]
+
+==== Response Body
+include::{snippets}/attendance/getAttendance_byMemberSeqAndDate/response-body.adoc[]
+
+==== Response
+include::{snippets}/attendance/getAttendance_byMemberSeqAndDate/response-fields.adoc[]
+
+==== Response paging link
+include::{snippets}/attendance/getAttendance_byMemberSeqAndDate/links.adoc[]
+
+
+
+[[matching-API]]
+== 매칭 API
+
+
+[[getMatching_monthly]]
+=== 월별 매칭 내역 조회
+
+==== Request HTTP
+include::{snippets}/matching/getMatching_monthly/http-request.adoc[]
+
+==== Request path parameters
+include::{snippets}/matching/getMatching_monthly/path-parameters.adoc[]
+
+==== Response Body
+include::{snippets}/matching/getMatching_monthly/response-body.adoc[]
+
+==== Response
+include::{snippets}/matching/getMatching_monthly/response-fields.adoc[]
+
+==== Response paging link
+include::{snippets}/matching/getMatching_monthly/links.adoc[]
+
+
+[[getMatching_daily]]
+=== 일별 매칭 내역 조회
+
+==== Request HTTP
+include::{snippets}/matching/getMatching_daily/http-request.adoc[]
+
+==== Request path parameters
+include::{snippets}/matching/getMatching_daily/path-parameters.adoc[]
+
+==== Response Body
+include::{snippets}/matching/getMatching_daily/response-body.adoc[]
+
+==== Response
+include::{snippets}/matching/getMatching_daily/response-fields.adoc[]
+
+==== Response paging link
+include::{snippets}/matching/getMatching_daily/links.adoc[]
+
+
+[[createMatching]]
+=== 매칭 생성
+
+==== Request HTTP
+include::{snippets}/matching/createMatching/http-request.adoc[]
+
+==== Request
+include::{snippets}/matching/createMatching/request-fields.adoc[]
+
+==== Response Body
+include::{snippets}/matching/createMatching/response-body.adoc[]
+
+==== Response
+include::{snippets}/matching/createMatching/response-fields.adoc[]
+
+==== Response paging link
+include::{snippets}/matching/createMatching/links.adoc[]
+
+
+
+[[calculation-API]]
+== 정산 API
+
+
+[[getAllCalculations]]
+=== 정산 조회
+
+==== Request HTTP
+include::{snippets}/calculation/getAllCalculations/http-request.adoc[]
+
+==== Request path parameters
+include::{snippets}/calculation/getAllCalculations/path-parameters.adoc[]
+
+==== Response
+include::{snippets}/calculation/getAllCalculations/response-fields.adoc[]

--- a/src/test/java/com/uad2/application/BaseControllerTest.java
+++ b/src/test/java/com/uad2/application/BaseControllerTest.java
@@ -12,7 +12,6 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
@@ -30,7 +29,6 @@ import java.util.TimeZone;
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @AutoConfigureMockMvc
-@AutoConfigureRestDocs(outputDir = "target/generated-snippets/sample")
 @Import(RestDocsConfiguration.class)
 @Ignore
 public class BaseControllerTest {

--- a/src/test/java/com/uad2/application/api/document/utils/DocumentFormatGenerator.java
+++ b/src/test/java/com/uad2/application/api/document/utils/DocumentFormatGenerator.java
@@ -10,8 +10,12 @@ import static org.springframework.restdocs.snippet.Attributes.key;
  */
 public interface DocumentFormatGenerator {
 
-    static Attributes.Attribute getDateFormat() {
+    static Attributes.Attribute getDateTimeFormat() {
         return key("format").value("yyyy-MM-dd hh:mm:ss");
+    }
+
+    static Attributes.Attribute getDateFormat() {
+        return key("format").value("yyyy-MM-dd");
     }
 
 }

--- a/src/test/java/com/uad2/application/calculation/controller/CalculationControllerTests.java
+++ b/src/test/java/com/uad2/application/calculation/controller/CalculationControllerTests.java
@@ -9,14 +9,24 @@ import com.uad2.application.BaseControllerTest;
 import com.uad2.application.common.TestDescription;
 import com.uad2.application.common.enumData.CookieName;
 import org.junit.Test;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.mock.web.MockCookie;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
 
 import javax.transaction.Transactional;
+
+import static com.uad2.application.api.document.utils.DocumentFormatGenerator.getDateFormat;
+import static com.uad2.application.api.document.utils.DocumentFormatGenerator.getDateTimeFormat;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@AutoConfigureRestDocs(outputDir = "target/generated-snippets/calculation")
 public class CalculationControllerTests  extends BaseControllerTest {
     @Test
     @Transactional
@@ -44,7 +54,28 @@ public class CalculationControllerTests  extends BaseControllerTest {
         );
         // result
         result.andExpect(status().isOk())
-                .andDo(print());
+                .andDo(print())
+                .andDo(document("getAllCalculations",
+                        pathParameters(
+                                parameterWithName("year").description("졍산 연도"),
+                                parameterWithName("month").description("정산 월"),
+                                parameterWithName("memberSeq").description("회원 인덱스")
+                        ),
+                        responseFields(
+                                subsectionWithPath("calculationList").description("정산 매칭 데이터 리스트"),
+                                subsectionWithPath("count").description("카운팅"),
+                                subsectionWithPath("totalCount").description("누적 카운팅"),
+                                fieldWithPath("calculationList[].seq").type(JsonFieldType.NUMBER).description("회원 인덱스"),
+                                fieldWithPath("calculationList[].matching").type(JsonFieldType.OBJECT).description("매칭 정보"),
+                                fieldWithPath("calculationList[].price").type(JsonFieldType.NUMBER).description("회비"),
+                                fieldWithPath("calculationList[].content").type(JsonFieldType.STRING).description("설명"),
+                                fieldWithPath("calculationList[].kind").type(JsonFieldType.NUMBER).description("종류"),
+                                fieldWithPath("calculationList[].calculationDate").type(JsonFieldType.STRING).attributes(getDateFormat()).description("정산일"),
+                                fieldWithPath("calculationList[].attendCnt").type(JsonFieldType.NUMBER).description("참가 회원 카운팅"),
+                                fieldWithPath("calculationList[].createAt").type(JsonFieldType.STRING).attributes(getDateTimeFormat()).description("생성일"),
+                                fieldWithPath("calculationList[].updateAt").type(JsonFieldType.STRING).attributes(getDateTimeFormat()).description("수정일")
+                        )
+                ));
     }
 
     @Test

--- a/src/test/java/com/uad2/application/matching/controller/MatchingControllerTests.java
+++ b/src/test/java/com/uad2/application/matching/controller/MatchingControllerTests.java
@@ -6,30 +6,37 @@ package com.uad2.application.matching.controller;
  */
 
 import com.uad2.application.BaseControllerTest;
-import com.uad2.application.attendance.dto.AttendanceDto;
 import com.uad2.application.common.TestDescription;
-import com.uad2.application.common.enumData.CookieName;
 import com.uad2.application.matching.dto.MatchingDto;
 import org.junit.Test;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockCookie;
-import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
 
 import javax.transaction.Transactional;
 
+import static com.uad2.application.api.document.utils.DocumentFormatGenerator.getDateFormat;
+import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithRel;
+import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.links;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-
+@AutoConfigureRestDocs(outputDir = "target/generated-snippets/matching")
 public class MatchingControllerTests extends BaseControllerTest {
     @Test
     @Transactional
     @TestDescription("월별 매칭 내역 조회")
     public void getMatching_monthly() throws Exception {
-        String[] paramList = new String[]{"2019-11"};
+        String[] paramList = new String[]{"2019-12"};
         MockCookie[] userMemberCookieList = super.getUserMemberCookieList(AUTOLOGIN_FALSE);
         // request
         ResultActions result = mockMvc.perform(
@@ -39,7 +46,26 @@ public class MatchingControllerTests extends BaseControllerTest {
         // result
         result.andExpect(status().isOk())
                 .andExpect(jsonPath("attendanceList").isNotEmpty())
-                .andDo(print());
+                .andDo(print())
+                .andDo(document("getMatching_monthly",
+                        pathParameters(
+                                parameterWithName("date").description("조회 월 (yyyy-MM)")
+                        ),
+                        links(
+                                linkWithRel("profile").description("restDoc link")
+                        ),
+                        responseFields(
+                                subsectionWithPath("attendanceList").description("매칭 데이터 리스트"),
+                                subsectionWithPath("_links").description("링크"),
+                                fieldWithPath("attendanceList[].matchingDate").type(JsonFieldType.STRING).attributes(getDateFormat()).description("매칭일"),
+                                fieldWithPath("attendanceList[].matchingTime").type(JsonFieldType.STRING).description("매칭 시간"),
+                                fieldWithPath("attendanceList[].matchingPlace").type(JsonFieldType.STRING).description("매칭 장소"),
+                                fieldWithPath("attendanceList[].content").type(JsonFieldType.STRING).description("매칭 설명"),
+                                fieldWithPath("attendanceList[].attendMember").type(JsonFieldType.STRING).description("참가 회원"),
+                                fieldWithPath("attendanceList[].maxCnt").type(JsonFieldType.NUMBER).description("최대 참석 가능 인원").optional(),
+                                fieldWithPath("attendanceList[].price").type(JsonFieldType.NUMBER).description("매칭 금액")
+                        )
+                ));
     }
     @Test
     @Transactional
@@ -70,7 +96,26 @@ public class MatchingControllerTests extends BaseControllerTest {
         // result
         result.andExpect(status().isOk())
                 .andExpect(jsonPath("attendanceList").isNotEmpty())
-                .andDo(print());
+                .andDo(print())
+                .andDo(document("getMatching_daily",
+                        pathParameters(
+                                parameterWithName("date").description("조회 일 (yyyy-MM-dd)")
+                        ),
+                        links(
+                                linkWithRel("profile").description("restDoc link")
+                        ),
+                        responseFields(
+                                subsectionWithPath("attendanceList").description("매칭 데이터 리스트"),
+                                subsectionWithPath("_links").description("링크"),
+                                fieldWithPath("attendanceList[].matchingDate").type(JsonFieldType.STRING).attributes(getDateFormat()).description("매칭일"),
+                                fieldWithPath("attendanceList[].matchingTime").type(JsonFieldType.STRING).description("매칭 시간"),
+                                fieldWithPath("attendanceList[].matchingPlace").type(JsonFieldType.STRING).description("매칭 장소"),
+                                fieldWithPath("attendanceList[].content").type(JsonFieldType.STRING).description("매칭 설명"),
+                                fieldWithPath("attendanceList[].attendMember").type(JsonFieldType.STRING).description("참가 회원"),
+                                fieldWithPath("attendanceList[].maxCnt").type(JsonFieldType.NUMBER).description("최대 참석 가능 인원").optional(),
+                                fieldWithPath("attendanceList[].price").type(JsonFieldType.NUMBER).description("매칭 금액")
+                        )
+                ));
     }
     @Test
     @Transactional
@@ -93,7 +138,33 @@ public class MatchingControllerTests extends BaseControllerTest {
         );
         // result
         result.andExpect(status().isCreated())
-                .andDo(print());
+                .andDo(print())
+                .andDo(document("createMatching",
+                        requestFields(
+                                fieldWithPath("matchingDate").type(JsonFieldType.STRING).attributes(getDateFormat()).description("매칭일 (yyyy-MM-dd)"),
+                                fieldWithPath("matchingTime").type(JsonFieldType.STRING).description("매칭 시간"),
+                                fieldWithPath("matchingPlace").type(JsonFieldType.STRING).description("매칭 장소"),
+                                fieldWithPath("content").type(JsonFieldType.STRING).description("매칭 설명"),
+                                fieldWithPath("attendMember").type(JsonFieldType.STRING).description("참가 회원"),
+                                fieldWithPath("price").type(JsonFieldType.NUMBER).description("매칭 금액"),
+                                fieldWithPath("seq").type(JsonFieldType.NUMBER).ignored(),
+                                fieldWithPath("maxCnt").type(JsonFieldType.NUMBER).ignored()
+                        ),
+                        links(
+                                linkWithRel("profile").description("restDoc link")
+                        ),
+                        responseFields(
+                                subsectionWithPath("attendance").description("매칭 데이터"),
+                                subsectionWithPath("_links").description("링크"),
+                                fieldWithPath("attendance.matchingDate").type(JsonFieldType.STRING).attributes(getDateFormat()).description("매칭일"),
+                                fieldWithPath("attendance.matchingTime").type(JsonFieldType.STRING).description("매칭 시간"),
+                                fieldWithPath("attendance.matchingPlace").type(JsonFieldType.STRING).description("매칭 장소"),
+                                fieldWithPath("attendance.content").type(JsonFieldType.STRING).description("매칭 설명"),
+                                fieldWithPath("attendance.attendMember").type(JsonFieldType.STRING).description("참가 회원"),
+                                fieldWithPath("attendance.maxCnt").type(JsonFieldType.NUMBER).description("최대 참석 가능 인원").optional(),
+                                fieldWithPath("attendance.price").type(JsonFieldType.NUMBER).description("매칭 금액")
+                        )
+                ));
 
     }
     @Test

--- a/src/test/java/com/uad2/application/member/controller/MemberControllerTests.java
+++ b/src/test/java/com/uad2/application/member/controller/MemberControllerTests.java
@@ -6,11 +6,12 @@ package com.uad2.application.member.controller;
  */
 
 import com.uad2.application.BaseControllerTest;
-import com.uad2.application.common.enumData.CookieName;
 import com.uad2.application.common.TestDescription;
+import com.uad2.application.common.enumData.CookieName;
 import com.uad2.application.member.dto.MemberDto;
 import com.uad2.application.utils.CookieUtil;
 import org.junit.Test;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -19,7 +20,9 @@ import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
 
 import javax.transaction.Transactional;
-import java.util.*;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithRel;
 import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.links;
@@ -30,12 +33,15 @@ import static org.springframework.restdocs.request.RequestDocumentation.pathPara
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+@AutoConfigureRestDocs(outputDir = "target/generated-snippets/member")
 public class MemberControllerTests extends BaseControllerTest {
+
     @Test
     @Transactional
     @TestDescription("전체 회원 조회")
     public void getAllMembers() throws Exception {
         MockCookie[] adminMemberCookieList = super.getAdminMemberCookieList(AUTOLOGIN_FALSE);
+
         // request
         ResultActions result = mockMvc.perform(
                 super.getRequest("/api/member", adminMemberCookieList)
@@ -51,7 +57,20 @@ public class MemberControllerTests extends BaseControllerTest {
                         ),
                         responseFields(
                                 subsectionWithPath("memberList").description("전체 회원 데이터 리스트"),
-                                subsectionWithPath("_links").description("링크")
+                                subsectionWithPath("_links").description("링크"),
+                                fieldWithPath("memberList[].seq").description("인덱스").type(JsonFieldType.NUMBER),
+                                fieldWithPath("memberList[].id").description("아이디").type(JsonFieldType.STRING),
+                                fieldWithPath("memberList[].name").description("이름").type(JsonFieldType.STRING),
+                                fieldWithPath("memberList[].profileImg").description("프로필 이미지").type(JsonFieldType.STRING).optional(),
+                                fieldWithPath("memberList[].attdCnt").description("누적 참석 횟수").type(JsonFieldType.NUMBER),
+                                fieldWithPath("memberList[].birthDay").description("생년월일").type(JsonFieldType.STRING),
+                                fieldWithPath("memberList[].studentId").description("학번").type(JsonFieldType.NUMBER),
+                                fieldWithPath("memberList[].isWorker").description("직장인 여부").type(JsonFieldType.NUMBER),
+                                fieldWithPath("memberList[].phoneNumber").description("핸드폰 번호").type(JsonFieldType.STRING).optional(),
+                                fieldWithPath("memberList[].sessionId").description("세션 ID").type(JsonFieldType.STRING).optional(),
+                                fieldWithPath("memberList[].sessionLimit").description("세션 만료일").type(JsonFieldType.STRING).optional(),
+                                fieldWithPath("memberList[].isAdmin").description("관리자 권한 여부").type(JsonFieldType.NUMBER),
+                                fieldWithPath("memberList[].isBenefit").description("특혜 (회비 면제)").type(JsonFieldType.NUMBER)
                         )
                 ));
     }
@@ -106,7 +125,20 @@ public class MemberControllerTests extends BaseControllerTest {
                         ),
                         responseFields(
                                 subsectionWithPath("member").description("회원 데이터"),
-                                subsectionWithPath("_links").description("링크")
+                                subsectionWithPath("_links").description("링크"),
+                                fieldWithPath("member.seq").description("인덱스").type(JsonFieldType.NUMBER),
+                                fieldWithPath("member.id").description("아이디").type(JsonFieldType.STRING),
+                                fieldWithPath("member.name").description("이름").type(JsonFieldType.STRING),
+                                fieldWithPath("member.profileImg").description("프로필 이미지").type(JsonFieldType.STRING).optional(),
+                                fieldWithPath("member.attdCnt").description("누적 참석 횟수").type(JsonFieldType.NUMBER),
+                                fieldWithPath("member.birthDay").description("생년월일").type(JsonFieldType.STRING),
+                                fieldWithPath("member.studentId").description("학번").type(JsonFieldType.NUMBER),
+                                fieldWithPath("member.isWorker").description("직장인 여부").type(JsonFieldType.NUMBER),
+                                fieldWithPath("member.phoneNumber").description("핸드폰 번호").type(JsonFieldType.STRING).optional(),
+                                fieldWithPath("member.sessionId").description("세션 ID").type(JsonFieldType.STRING).optional(),
+                                fieldWithPath("member.sessionLimit").description("세션 만료일").type(JsonFieldType.STRING).optional(),
+                                fieldWithPath("member.isAdmin").description("관리자 권한 여부").type(JsonFieldType.NUMBER),
+                                fieldWithPath("member.isBenefit").description("특혜 (회비 면제)").type(JsonFieldType.NUMBER)
                         )
                 ));
     }
@@ -201,7 +233,7 @@ public class MemberControllerTests extends BaseControllerTest {
                                 fieldWithPath("id").type(JsonFieldType.STRING).description("아이디"),
                                 fieldWithPath("pwd").type(JsonFieldType.STRING).description("비밀번호"),
                                 fieldWithPath("name").type(JsonFieldType.STRING).description("이름"),
-                                fieldWithPath("birthDay").type(JsonFieldType.STRING).description("생일"),
+                                fieldWithPath("birthDay").type(JsonFieldType.STRING).description("생일 (yyyy-MM-dd hh:mm:ss)"),
                                 fieldWithPath("studentId").type(JsonFieldType.NUMBER).description("학번"),
                                 fieldWithPath("isWorker").type(JsonFieldType.NUMBER).description("직장인 여부"),
                                 fieldWithPath("phoneNumber").type(JsonFieldType.STRING).description("핸드폰 번호"),
@@ -461,4 +493,36 @@ public class MemberControllerTests extends BaseControllerTest {
     public void testTest(int n1){
         Assert.assertEquals(n1,0);
     }*/
+
+    @Test
+    @Transactional
+    @TestDescription("비밀번호 체크 테스트")
+    public void checkPwd_when_usingFor_updateProfile() throws Exception {
+        MockCookie[] adminMemberCookieList = super.getAdminMemberCookieList(AUTOLOGIN_FALSE);
+
+        Map<String, String> request = new HashMap<>();
+        request.put("id", "testUser");
+        request.put("pwd", "12345678");
+
+        // request
+        ResultActions result = mockMvc.perform(
+                super.postRequest("/api/member/checkPwd", request, adminMemberCookieList)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        );
+        // result
+        result.andExpect(status().isOk())
+                .andDo(print())
+                .andExpect(jsonPath("isSamePwd").exists())
+                .andDo(document("checkPwd",
+                        requestFields(
+                                fieldWithPath("id").type(JsonFieldType.STRING).description("아이디"),
+                                fieldWithPath("pwd").type(JsonFieldType.STRING).description("비밀번호")
+                        ),
+                        responseFields(
+                                fieldWithPath("isSamePwd").description("비밀번호 일치 여부").type(JsonFieldType.BOOLEAN)
+                        )
+                ));
+    }
+
+
 }


### PR DESCRIPTION
## RESTDocs 명세서 자동화

- Member  / Attendance / Matching / Calculation
>- 우선적으로 필수 API에 대한 명세 추가 
>- 추후에 예외 상황에 대한 명세 추가 해야함
- resources\static\docs\index.html 참고

### 개선했으면 좋겠는 점
- 현재의 테스트 코드가 Service와 Repository 레이어에 의존적이다보니, 명세를 만드는 데 실제 DB의 데이터를 사용한다.
- 다른 레이어에 의존적이다보니 원하는 대로 데이터를 조작하는 것에 제약이 많다.
- 테스트 코드에 대한 의존성 분리가 필요해보임